### PR TITLE
Json toString should not throw as it makes match result not legible

### DIFF
--- a/src/main/scala/com/wix/peninsula/Json.scala
+++ b/src/main/scala/com/wix/peninsula/Json.scala
@@ -121,7 +121,9 @@ case class Json(node: JValue = JObject(), implicit val formats: DefaultFormats =
     else this
   }
 
-  override def toString: String = JsonMethods.pretty(JsonMethods.render(node))
+  override def toString: String =
+    if (node == null || formats == null) s"${this.getClass.getSimpleName}($node,$formats)"
+    else JsonMethods.pretty(JsonMethods.render(node))
 
   def getTypeString: String = node match {
     case _: JObject => "object"

--- a/src/test/scala/com/wix/peninsula/StringifyTest.scala
+++ b/src/test/scala/com/wix/peninsula/StringifyTest.scala
@@ -1,0 +1,43 @@
+package com.wix.peninsula
+
+import org.specs2.execute.Result
+import org.specs2.matcher.MustExpectable
+import org.specs2.mutable.SpecificationWithJUnit
+
+
+class StringifyTest extends SpecificationWithJUnit {
+
+  "matcher error" should {
+    "be informative" >> {
+      val result = MustExpectable.apply(Json(null, null)).applyMatcher(beEqualTo(Json()))
+      result.message must beEqualTo("'Json(null,null)' is not equal to '{ }'")
+    }
+  }
+
+  "toString" should {
+
+    "return <null> when initialized with nulls" >> {
+      Json(null, null).toString must beEqualTo("Json(null,null)")
+    }
+
+    "return <null> when node initialized with null" >> {
+      Json(null).toString must beMatching("Json\\(null,org.json4s.DefaultFormats.+\\)")
+    }
+
+    "return <null format> when format is null" >> {
+      Json.parse("""{"a":1}""").copy(formats = null).toString must beEqualTo("Json(JObject(List((a,JInt(1)))),null)")
+    }
+
+    "default object" >> {
+      Json().toString must beEqualTo("{ }")
+    }
+
+    "render pretty JSON" >> {
+      Json.parse("""{"a":1}""").toString must beEqualTo(
+        """{
+          |  "a" : 1
+          |}""".stripMargin)
+    }
+  }
+
+}


### PR DESCRIPTION
There are problematic cases in the wild when `Json` case class gets created with `null`s -- Jackson 2.9 parsing empty objects into `Json` is one. The problem is that when comparing `Json(null, null)` to just about anything and comparison fails, Specs2 invokes `Json(null, null).toString`, which fails with cryptic exception: `java.lang.NullPointerException: Cannot invoke "org.json4s.Formats.emptyValueStrategy()" because "formats" is null`. While `null` is the problem, the error message is indirect and not useful for debugging. Another case is when debugging with IntelliJ and it starts showing NPE's in the watch window.

This PR would improve DevEx by showing nicer match errors like this:
`'Json(null,null)' is not equal to '{ }'`